### PR TITLE
feat(middleware): add i18n bypass for short links and go routes

### DIFF
--- a/src/app/[locale]/preview/[code]/page.tsx
+++ b/src/app/[locale]/preview/[code]/page.tsx
@@ -153,7 +153,7 @@ export default function PreviewPage({ params }: PreviewPageProps) {
               </span>
               <span>•</span>
               <span>
-                {t("created")}:{" "}
+                {t("created")}: {" "}
                 {new Date(link.createdAt).toLocaleDateString(t("locale"))}
               </span>
             </div>
@@ -181,6 +181,7 @@ export default function PreviewPage({ params }: PreviewPageProps) {
         </Link>
         <Link
           href={`/go/${code}`}
+          locale={false}
           target="_blank"
           className="btn-primary space-x-2"
         >
@@ -188,36 +189,6 @@ export default function PreviewPage({ params }: PreviewPageProps) {
           {t("goToSite")}
         </Link>
       </div>
-
-      {/* Safety Notice */}
-      {/* <div className="mt-8 p-4 bg-blue-50 rounded-lg">
-        <div className="flex">
-          <div className="flex-shrink-0">
-            <svg
-              className="h-5 w-5 text-blue-400"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-            >
-              <path
-                fillRule="evenodd"
-                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </div>
-          <div className="ml-3">
-            <h3 className="text-sm font-medium text-blue-800">
-              Dica de Segurança
-            </h3>
-            <div className="mt-2 text-sm text-blue-700">
-              <p>
-                Sempre verifique se o link é confiável antes de clicar. Evite
-                inserir informações pessoais em sites desconhecidos.
-              </p>
-            </div>
-          </div>
-        </div>
-      </div> */}
     </div>
   );
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,22 @@
 import createMiddleware from 'next-intl/middleware';
+import { NextRequest, NextResponse } from 'next/server';
 import { locales, defaultLocale } from './i18n';
 
-export default createMiddleware({
+export default function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Bypassa i18n para rotas de redirecionamento
+  const isGoRoute = pathname.startsWith('/go');
+  const isRootShortCode = /^\/[a-zA-Z0-9]{4,8}(?:\/)?$/.test(pathname);
+
+  if (isGoRoute || isRootShortCode) {
+    return NextResponse.next();
+  }
+
+  return intlMiddleware(request);
+}
+
+const intlMiddleware = createMiddleware({
   // Lista de idiomas suportados
   locales,
   
@@ -18,7 +33,7 @@ export default createMiddleware({
 export const config = {
   // Matcher para aplicar o middleware em todas as rotas relevantes
   matcher: [
-    // Incluir todas as rotas exceto arquivos estáticos, API e requisições RSC
-    '/((?!api|_next/static|_next/image|favicon.ico|.*\._rsc.*|.*\.png$|.*\.jpg$|.*\.jpeg$|.*\.gif$|.*\.svg$|.*\.ico$|.*\.webp$|.*\.css$|.*\.js$|.*\.json$|.*\.xml$|.*\.txt$).*)'
+    // Incluir todas as rotas exceto arquivos estáticos, API, rota de links encurtados (/go) e requisições RSC
+    '/((?!api|go|_next/static|_next/image|favicon.ico|.*\._rsc.*|.*\.png$|.*\.jpg$|.*\.jpeg$|.*\.gif$|.*\.svg$|.*\.ico$|.*\.webp$|.*\.css$|.*\.js$|.*\.json$|.*\.xml$|.*\.txt$).*)'
   ]
 };


### PR DESCRIPTION
Add middleware logic to bypass i18n handling for /go routes and root short codes Update matcher config to exclude /go routes from i18n processing Fix spacing in preview page date display and disable locale for go link